### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/rhet-butler.gemspec
+++ b/rhet-butler.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |spec|
   design it in CSS, run the presentation with your smartphone over Websockets.
   EndDescription
 
-  spec.rubyforge_project= spec.name.downcase
   spec.homepage        = "http://nyarly.github.com/#{spec.name.downcase}"
   spec.required_rubygems_version = Gem::Requirement.new(">= 0") if spec.respond_to? :required_rubygems_version=
 


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.